### PR TITLE
Only hash relevant subset of ByteBuffer

### DIFF
--- a/java/src/main/java/com/somethingsimilar/opposite_of_a_bloom_filter/OoaBFilter.java
+++ b/java/src/main/java/com/somethingsimilar/opposite_of_a_bloom_filter/OoaBFilter.java
@@ -86,7 +86,7 @@ public class OoaBFilter {
    */
   public boolean containsAndAdd(Element element) {
     ByteBuffer eBytes = element.getByteBuffer();
-    HashCode code = HASH_FUNC.hashBytes(eBytes.array());
+    HashCode code = HASH_FUNC.hashBytes(eBytes.array(), eBytes.arrayOffset() + eBytes.position(), eBytes.remaining());
     int index = code.asInt() & sizeMask;
 
     boolean seen = true;


### PR DESCRIPTION
In the `ByteBuffer` implementation, only the bytes `remaining()` from the current `position()` are relevant data. The backing `array()` could well contain additional data that is not a part of the element (e.g. if the `ByteBuffer` has been sliced from a larger buffer).

Both the comparison of the existing element to the new element, and the copy of the element in to the filter operate only on the subset of the buffer between `position()` and `remaining()`; the hashing of the element should too.
