### PR TITLE
add go.mod and fix go vet errors

### DIFF
--- a/go/oppobloom/go.mod
+++ b/go/oppobloom/go.mod
@@ -1,0 +1,3 @@
+module github.com/jmhodges/opposite_of_a_bloom_filter/go/oppobloom
+
+go 1.21.5

--- a/go/oppobloom/oppobloom_test.go
+++ b/go/oppobloom/oppobloom_test.go
@@ -31,15 +31,15 @@ func TestTheBasics(t *testing.T) {
 func TestSizeRounding(t *testing.T) {
 	f, _ := NewFilter(3)
 	if f.Size() != 4 {
-		t.Errorf("3 should round to 4, rounded to: ", f.Size())
+		t.Errorf("3 should round to 4, rounded to: %d", f.Size())
 	}
 	f, _ = NewFilter(4)
 	if f.Size() != 4 {
-		t.Errorf("4 should round to 4", f.Size())
+		t.Errorf("4 should round to 4")
 	}
 	f, _ = NewFilter(129)
 	if f.Size() != 256 {
-		t.Errorf("129 should round to 256", f.Size())
+		t.Errorf("129 should round to 256, rounded to: %d", f.Size())
 	}
 }
 


### PR DESCRIPTION
The go.mod is to behave more like a modern Go project and we fix the `go
vet` errors around Errorf as we go.
