### PR TITLE
use fnv instead of incorrect md5

### DIFF
--- a/go/oppobloom/oppobloom.go
+++ b/go/oppobloom/oppobloom.go
@@ -8,9 +8,8 @@ package oppobloom
 
 import (
 	"bytes"
-	"crypto/md5"
 	"errors"
-	"hash"
+	"hash/fnv"
 	"math"
 	"sync/atomic"
 	"unsafe"
@@ -40,7 +39,7 @@ func NewFilter(size int) (*Filter, error) {
 }
 
 func (f *Filter) Contains(id []byte) bool {
-	h := md5UintHash{md5.New()}
+	h := fnv.New32()
 	h.Write(id)
 	uindex := h.Sum32() & f.sizeMask
 	index := int32(uindex)
@@ -50,20 +49,6 @@ func (f *Filter) Contains(id []byte) bool {
 
 func (f *Filter) Size() int {
 	return len(f.array)
-}
-
-type md5UintHash struct {
-	hash.Hash // a hack with knowledge of how md5 works
-}
-
-func (m md5UintHash) Sum32() uint32 {
-	sum := m.Sum(nil)
-	x := uint32(sum[0])
-	for _, val := range sum[1:3] {
-		x = x << 3
-		x += uint32(val)
-	}
-	return x
 }
 
 // Returns the id that was in the slice at the given index after putting the

--- a/go/oppobloom/oppobloom_test.go
+++ b/go/oppobloom/oppobloom_test.go
@@ -11,14 +11,14 @@ func TestTheBasics(t *testing.T) {
 	f, _ := NewFilter(2)
 	twentyNineId := []byte{27, 28, 29}
 	thirtyId := []byte{27, 28, 30}
-	thirtyThreeId := []byte{27, 28, 33}
+	thirtyThreeId := []byte{27, 28, 32}
 	shouldNotContain(t, "nothing should be contained at all", f, twentyNineId)
 	shouldContain(t, "now it should", f, twentyNineId)
 	shouldNotContain(t, "false unless the hash collides", f, thirtyId)
 	shouldContain(t, "original should still return true", f, twentyNineId)
 	shouldContain(t, "new array should still return true", f, thirtyId)
 
-	// Handling collisions. {27, 28, 33} and {27, 28, 30} hash to the same
+	// Handling collisions. {27, 28, 33} and {27, 28, 32} hash to the same
 	// index using the current hash function inside Filter.
 	shouldNotContain(t, "colliding array returns false", f, thirtyThreeId)
 	shouldContain(t,
@@ -65,12 +65,14 @@ func TestTooSmallSize(t *testing.T) {
 }
 
 func shouldContain(t *testing.T, msg string, f *Filter, id []byte) {
+	t.Helper()
 	if !f.Contains(id) {
 		t.Errorf("should contain, %s: id %v, array: %v", msg, id, f.array)
 	}
 }
 
 func shouldNotContain(t *testing.T, msg string, f *Filter, id []byte) {
+	t.Helper()
 	if f.Contains(id) {
 		t.Errorf("should not contain, %s: %v", msg, id)
 	}


### PR DESCRIPTION
The homegrown Sum32 was wrong and md5 is slow, anyhow. fnv isn't
stellar, but it's predictable and folks can swap it out in their own
implementations.

The test vectors get some mild changes to account for the new hash, and
we litter some t.Helper calls to clarify test failures.

Fixes #11
