### PR TITLE
use more recent maven dep submitter GHA

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,6 +39,6 @@ jobs:
 
       # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
       - name: Update dependency graph
-        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+        uses: advanced-security/maven-dependency-submission-action@v3.0.3
         with:
           directory: java


### PR DESCRIPTION
The previous version had set-output warnings and failed to store report
snapshots sometimes (e.g.
https://github.com/jmhodges/opposite_of_a_bloom_filter/actions/runs/7262072116/job/19784593080)
