### PR TITLE
bump guava 11.0.2 to 33.0.0-jre

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>11.0.2</version>
+            <version>33.0.0-jre</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Manual work since dependabot is complaining about security problems in
the old version. Plus, showing this works on more recent versions is
kinder to readers.
